### PR TITLE
feat(Dockerfile): go-dev updates for smaller image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || echo latest)
-REGISTRY ?= quay.io/
-IMAGE_PREFIX ?= deis
+REGISTRY ?= docker.io/
+IMAGE_PREFIX ?= hephy
 IMAGE := ${REGISTRY}${IMAGE_PREFIX}/go-dev:${VERSION}
 
 # scripts are checked *after* build, so use paths inside the container

--- a/README.md
+++ b/README.md
@@ -1,18 +1,15 @@
-# deis/go-dev
+# hephy/go-dev
 
-[![Build Status](https://github.com/deis/docker-go-dev/actions/workflows/docker-publish.yml/badge.svg)](https://quay.io/repository/deis/go-dev?tab=tags)
+[![Build Status](https://github.com/teamhephy/docker-go-dev/actions/workflows/docker-publish.yml/badge.svg)](https://hub.docker.com/r/hephy/go-dev/tags)
 
 A [Go][] language development toolbox.
 
-Some Azure projects use this Docker image as a standard build and test environment,
-but it is intended to be useful to any Go developer. Please help make deis/go-dev better by
+This image is intended to be useful to any Go developer. Please help make hephy/go-dev better by
 creating [issues][] and submitting [pull requests][].
 
 ## Image Contents
 
-* based on [Ubuntu 18.04][]
-* [az][]: Azure cloud command-line tool
-* [azcopy][]: Utility for copying data to/from Microsoft Azure Blob and File storage
+* based on [Ubuntu 20.04][]
 * [delve][]: debugger for the Go programming language
 * [Docker][]: Docker binaries to be able to bind mount /var/run/docker.sock in the dev environment container
 * [ginkgo][]: BDD testing framework for Go
@@ -25,7 +22,6 @@ creating [issues][] and submitting [pull requests][].
 * [jwt][]: tool for creating and parsing JSON Web Tokens
 * [k][]: automatically run the correct version of `kubectl` every time
 * [kubectl][]: Kubernetes command-line client
-* [Packer][]: build automated machine images
 * [ruby][]: ruby scripting language
 * [shellcheck][]: static analysis for shell scripts
 * [shfmt][]: shell script parser, formatter, and interpreter
@@ -39,37 +35,26 @@ creating [issues][] and submitting [pull requests][].
 ## Usage
 
 Mount your local Go code into a container's `$GOPATH` to run any `go` command or one of the
-included tools or scripts. Here's an example of running `ginko` for deis/builder:
+included tools or scripts. Here's an example of running `ginko` for teamhephy/builder:
 
 ```console
 $ docker run --rm \
-  --volume $GOPATH/src/github.com/deis/builder:/go/src/github.com/deis/builder \
-  --workdir /go/src/github.com/deis/builder \
-  quay.io/deis/go-dev:latest \
+  --volume $GOPATH/src/github.com/teamhephy/builder:/go/src/github.com/teamhephy/builder \
+  --workdir /go/src/github.com/teamhephy/builder \
+  hephy/go-dev:latest \
   ginkgo -r
 ```
 
 ## Releases
 
-The latest deis/go-dev Docker image is available at:
-
-* [Microsoft Container Registry][]
-  ```
-  docker pull mcr.microsoft.com/oss/azcu/go-dev:<tag>
-  ```
-  Browse the [go-dev index URL][] to see which tags are available.
-
-* [Quay.io][]
-  ```
-  docker pull quay.io/deis/go-dev
-  ```
+The latest hephy/go-dev Docker image is available at:
 
 * [Docker Hub][]
   ```
-  docker pull deis/go-dev
+  docker pull hephy/go-dev
   ```
 
-To publish a new release of deis/go-dev, use the [deisrel][] tool:
+To publish a new release of hephy/go-dev, use the [deisrel][] tool:
 
 ```console
 $ deisrel release docker-go-dev v1.28.7
@@ -86,36 +71,30 @@ If the CHANGELOG contents look correct, run the same command again but add the a
 You will be prompted to confirm again before any tag or release is written to GitHub.
 
 
-[az]: https://github.com/Azure/azure-cli#readme
-[azcopy]: https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-linux?toc=%2fazure%2fstorage%2ffiles%2ftoc.json
-[deisrel]: https://github.com/deis/deisrel
+[deisrel]: https://github.com/teamhephy/deisrel
 [delve]: https://github.com/go-delve/delve
 [Docker Hub]: https://hub.docker.com
 [Docker]: http://www.docker.com
-[gen-changelog.sh]: https://github.com/deis/docker-go-dev/tree/master/rootfs/usr/local/bin/gen-changelog.sh
+[gen-changelog.sh]: https://github.com/teamhephy/docker-go-dev/tree/master/rootfs/usr/local/bin/gen-changelog.sh
 [ginkgo]: https://github.com/onsi/ginkgo
 [go-bindata]: https://github.com/jteeuwen/go-bindata
 [Go]: https://golang.org/
-[go-dev index URL]: https://mcr.microsoft.com/v2/oss/azcu/go-dev/tags/list
 [golangci-lint]: https://github.com/golangci/golangci-lint
 [goss]: https://github.com/aelsabbahy/goss
 [gox]: https://github.com/mitchellh/gox
 [helm]: https://github.com/kubernetes/helm
-[issues]: https://github.com/deis/docker-go-dev/issues
+[issues]: https://github.com/teamhephy/docker-go-dev/issues
 [jq]: https://stedolan.github.io/jq/
 [jwt]: https://github.com/dgrijalva/jwt-go
 [k]: https://github.com/jakepearson/k
 [kubectl]: https://kubernetes.io/docs/user-guide/kubectl-overview/
-[Microsoft Container Registry]: https://github.com/microsoft/containerregistry
-[pull requests]: https://github.com/deis/docker-go-dev/pulls
-[Quay.io]: https://quay.io
-[Packer]: https://github.com/hashicorp/packer
+[pull requests]: https://github.com/teamhephy/docker-go-dev/pulls
 [ruby]: https://www.ruby-lang.org/
 [shellcheck]: https://github.com/koalaman/shellcheck
 [shfmt]: https://github.com/mvdan/sh
 [shyaml]: https://github.com/0k/shyaml
-[test-cover.sh]: https://github.com/deis/docker-go-dev/tree/master/rootfs/usr/local/bin/test-cover.sh
-[Ubuntu 18.04]: https://hub.docker.com/_/ubuntu/
+[test-cover.sh]: https://github.com/teamhephy/docker-go-dev/tree/master/rootfs/usr/local/bin/test-cover.sh
+[Ubuntu 20.04]: https://hub.docker.com/_/ubuntu/
 [unzip]: https://linux.die.net/man/1/unzip
 [upx]: http://upx.sourceforge.net/
 [vim]: http://www.vim.org/

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,21 +1,16 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-LABEL name="deis-go-dev" \
-      maintainer="Matt Boersma <matt.boersma@microsoft.com>"
+LABEL name="hephy-go-dev" \
+      maintainer="Team Hephy <team@teamhephy.com>"
 
-ENV ANSIBLE_VERSION=2.10.9 \
-    AZCLI_VERSION=2.26.1 \
-    DOCKER_VERSION=20.10.2 \
+ENV DOCKER_VERSION=20.10.2 \
     ETCDCTL_VERSION=v3.1.8 \
     GO_VERSION=1.16.6 \
     GOLANGCI_LINT_VERSION=v1.41.1 \
     GOSS_VERSION=v0.3.16 \
     HELM_VERSION=3.6.2 \
     KUBECTL_VERSION=v1.21.3 \
-    PACKER_VERSION=1.7.3 \
     PROTOBUF_VERSION=3.7.0 \
-    PYJWT_VERSION=2.1.0 \
-    PYWINRM_VERSION=0.4.1 \
     SHELLCHECK_VERSION=v0.7.2 \
     SHFMT_VERSION=3.3.0 \
     UPX_VERSION=3.96 \
@@ -40,7 +35,7 @@ RUN \
     git-core \
     jq \
     libffi-dev \
-    libicu60 \
+    libc6 \
     libssl-dev \
     libunwind8 \
     man \
@@ -73,10 +68,6 @@ RUN \
   && chmod 700 get_helm.sh && ./get_helm.sh --version v${HELM_VERSION} \
   && rm ./get_helm.sh \
   && mkdir -p /go/bin \
-  && curl -sSL https://aka.ms/downloadazcopy-v10-linux | tar -vxz -C /usr/local/bin --strip=1 \
-  && mv /usr/local/bin/azcopy /usr/local/bin/azcopy-preview \
-  && curl -sSL https://aka.ms/downloadazcopylinux64 | tar -vxz -C /tmp \
-  && /tmp/install.sh \
   && apt-get update && apt-get -f -y install \
   && curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz \
   && tar xzvf docker-${DOCKER_VERSION}.tgz -C /usr/local/bin \
@@ -99,8 +90,6 @@ RUN \
   && curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ${GOPATH}/bin ${GOLANGCI_LINT_VERSION} \
   && curl -sSL https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz \
     | tar -vxJ -C /usr/local/bin --strip=1 \
-  && curl -sSL https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip -o /tmp/packer.zip \
-    && unzip /tmp/packer.zip -d /usr/local/bin \
   && curl -o /usr/local/bin/shfmt -sSL https://github.com/mvdan/sh/releases/download/v{SHFMT_VERSION}/shfmt_v{SHFMT_VERSION}_linux_amd64 \
   && chmod +x /usr/local/bin/shfmt \
   && curl -L "https://github.com/aelsabbahy/goss/releases/download/${GOSS_VERSION}/goss-linux-amd64" -o /usr/local/bin/goss \
@@ -111,8 +100,6 @@ RUN \
   && tar -xvf /tmp/upx.tar.xz -C /tmp \
   && mv /tmp/upx-${UPX_VERSION}-amd64_linux/upx /usr/local/bin/upx \
   && pip3 install --disable-pip-version-check --no-cache-dir --upgrade pip \
-  && pip3 install --disable-pip-version-check --no-cache-dir azure-cli==${AZCLI_VERSION} PyJWT==${PYJWT_VERSION} shyaml ansible-base==${ANSIBLE_VERSION} pywinrm==${PYWINRM_VERSION} \
-  && ansible-galaxy collection install ansible.windows \
   && apt-get purge --auto-remove -y libffi-dev python3-dev \
   && apt-get autoremove -y \
   && apt-get clean -y \

--- a/rootfs/usr/local/bin/lint
+++ b/rootfs/usr/local/bin/lint
@@ -2,21 +2,25 @@
 
 # Mandatory tests
 echo -e "\033[0;31mManadatory Linters: These must pass\033[0m"
-gometalinter --vendor --tests --deadline=300s --disable-all \
+golangci-lint run --modules-download-mode=vendor --tests --deadline=300s --disable-all \
 --enable=gofmt \
 --enable=misspell \
 --enable=deadcode \
 --enable=ineffassign \
 --enable=gosimple \
---enable=vet \
+--enable=govet \
+--enable=typecheck \
 ./...
 
 mandatory=$?
 
 # Optional tests
 echo -e "\033[0;32mOptional Linters: These should pass\033[0m"
-gometalinter --vendor --tests --deadline=300s --disable-all \
---enable=golint \
+golangci-lint run --modules-download-mode=vendor --tests --deadline=300s --disable-all \
+--enable=revive \
+--enable=gosec \
+--enable=gocognit \
+--enable=gocritic \
 ./...
 
 exit $mandatory


### PR DESCRIPTION
  - update base image to `ubuntu:20.04` focal lts
  - switch to `golangci-lint` for linter as `gometalinter` is DEPRECATED
  - `golint` is DEPRECATED in favor of drop-in replacement `revive`
  - enable `typecheck` linter as mandatory (pretty quiet linter)
  - enable `gosec`, `gocritic`, and `gocognit` as optional linters (useful)
  - drop library `libicu60` for library `libc6` that exists in focal
  - removing unused Azure packages like `azcopy`, `packer`, and many others etc.

Signed-off-by: Cryptophobia <aouzounov@gmail.com>